### PR TITLE
Remove apache2.pid file on re-run

### DIFF
--- a/run
+++ b/run
@@ -9,4 +9,7 @@ sed -ri "s/^error_reporting\s*=.*$//g" /etc/php5/cli/php.ini
 echo "error_reporting = $PHP_ERROR_REPORTING" >> /etc/php5/apache2/php.ini
 echo "error_reporting = $PHP_ERROR_REPORTING" >> /etc/php5/cli/php.ini
 
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
+
 source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND


### PR DESCRIPTION
See fix in official repo: https://github.com/docker-library/php/blob/bdfd0fc1d19102cd6f951614072a51eabf7191bf/5.6/apache/apache2-foreground